### PR TITLE
Add NotebookLM-style dashboard landing page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import SignIn from './pages/SignIn'
 import SignUp from './pages/SignUp'
 import RequestPasswordReset from './pages/RequestPasswordReset'
 import ResetPassword from './pages/ResetPassword'
+import NotebookDashboard from './pages/NotebookDashboard'
 import Notebooks from './pages/Notebooks'
 import './App.css'
 
@@ -19,7 +20,8 @@ function App() {
             <Route path="/signup" element={<SignUp />} />
             <Route path="/request-password-reset" element={<RequestPasswordReset />} />
             <Route path="/reset-password" element={<ResetPassword />} />
-            <Route path="/notebooks" element={<Notebooks />} />
+            <Route path="/notebooks" element={<NotebookDashboard />} />
+            <Route path="/notebooks/:notebookId" element={<Notebooks />} />
           </Routes>
         </div>
       </AuthProvider>

--- a/frontend/src/components/NotebookCard.tsx
+++ b/frontend/src/components/NotebookCard.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+interface NotebookCardProps {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: string;
+  sourcesCount?: number;
+  onClick: () => void;
+  onDelete: (e: React.MouseEvent) => void;
+}
+
+const NotebookCard: React.FC<NotebookCardProps> = ({
+  title,
+  content,
+  updatedAt,
+  sourcesCount = 0,
+  onClick,
+  onDelete,
+}) => {
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+    });
+  };
+
+  const getPreview = (text: string) => {
+    if (!text) return 'No notes yet';
+    return text.length > 120 ? text.substring(0, 120) + '...' : text;
+  };
+
+  const getColorFromTitle = (title: string) => {
+    const colors = [
+      '#4285f4', // blue
+      '#ea4335', // red
+      '#fbbc04', // yellow
+      '#34a853', // green
+      '#ff6d01', // orange
+      '#46bdc6', // teal
+      '#7baaf7', // light blue
+      '#f07b72', // light red
+    ];
+    let hash = 0;
+    for (let i = 0; i < title.length; i++) {
+      hash = title.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
+  };
+
+  return (
+    <div className="notebook-card" onClick={onClick}>
+      <div
+        className="notebook-card-header"
+        style={{ backgroundColor: getColorFromTitle(title) }}
+      >
+        <div className="notebook-card-icon">📓</div>
+        <button
+          className="notebook-card-menu"
+          onClick={onDelete}
+          title="Delete notebook"
+        >
+          ×
+        </button>
+      </div>
+      <div className="notebook-card-body">
+        <h3 className="notebook-card-title">{title}</h3>
+        <p className="notebook-card-preview">{getPreview(content)}</p>
+      </div>
+      <div className="notebook-card-footer">
+        <span className="notebook-card-date">{formatDate(updatedAt)}</span>
+        {sourcesCount > 0 && (
+          <span className="notebook-card-sources">
+            {sourcesCount} source{sourcesCount !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NotebookCard;

--- a/frontend/src/pages/NotebookDashboard.tsx
+++ b/frontend/src/pages/NotebookDashboard.tsx
@@ -1,0 +1,333 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { notebooksAPI } from '../utils/api';
+import { useAuth } from '../contexts/AuthContext';
+import NotebookCard from '../components/NotebookCard';
+import '../styles/NotebookDashboard.css';
+
+interface Notebook {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const NotebookDashboard: React.FC = () => {
+  const [notebooks, setNotebooks] = useState<Notebook[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [newNotebookTitle, setNewNotebookTitle] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const navigate = useNavigate();
+  const { user, signout } = useAuth();
+
+  useEffect(() => {
+    loadNotebooks();
+  }, []);
+
+  const loadNotebooks = async () => {
+    try {
+      setIsLoading(true);
+      setError('');
+      const data = await notebooksAPI.getAll();
+      setNotebooks(data.notebooks || []);
+    } catch (err) {
+      console.error('Load notebooks error:', err);
+      setError('Failed to load notebooks');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateNotebook = async () => {
+    if (!newNotebookTitle.trim()) return;
+
+    try {
+      setIsCreating(true);
+      const data = await notebooksAPI.create({
+        title: newNotebookTitle.trim(),
+        content: '',
+      });
+      setShowCreateModal(false);
+      setNewNotebookTitle('');
+      navigate(`/notebooks/${data.notebook.id}`);
+    } catch (err) {
+      console.error('Create notebook error:', err);
+      setError('Failed to create notebook');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleQuickCreate = async () => {
+    try {
+      setIsCreating(true);
+      const data = await notebooksAPI.create({
+        title: 'Untitled notebook',
+        content: '',
+      });
+      navigate(`/notebooks/${data.notebook.id}`);
+    } catch (err) {
+      console.error('Create notebook error:', err);
+      setError('Failed to create notebook');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleDeleteNotebook = async (e: React.MouseEvent, notebookId: string, title: string) => {
+    e.stopPropagation();
+
+    if (!window.confirm(`Delete "${title}"? This cannot be undone.`)) {
+      return;
+    }
+
+    try {
+      await notebooksAPI.delete(notebookId);
+      setNotebooks(notebooks.filter((n) => n.id !== notebookId));
+    } catch (err) {
+      console.error('Delete notebook error:', err);
+      setError('Failed to delete notebook');
+    }
+  };
+
+  const handleOpenNotebook = (notebookId: string) => {
+    navigate(`/notebooks/${notebookId}`);
+  };
+
+  const filteredNotebooks = notebooks.filter(
+    (notebook) =>
+      notebook.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      notebook.content.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const recentNotebooks = [...notebooks]
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 4);
+
+  if (isLoading) {
+    return (
+      <div className="dashboard">
+        <div className="dashboard-loading">
+          <div className="loading-spinner"></div>
+          <p>Loading your notebooks...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard">
+      {/* Header */}
+      <header className="dashboard-header">
+        <div className="header-left">
+          <div className="app-logo">
+            <span className="logo-icon">📔</span>
+            <span className="logo-text">NotebookLM</span>
+          </div>
+        </div>
+        <div className="header-center">
+          <div className="search-container">
+            <span className="search-icon">🔍</span>
+            <input
+              type="text"
+              placeholder="Search notebooks..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="search-input"
+            />
+            {searchQuery && (
+              <button
+                className="search-clear"
+                onClick={() => setSearchQuery('')}
+              >
+                ×
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="header-right">
+          <div className="user-menu">
+            <div className="user-avatar">
+              {user?.name?.charAt(0) || user?.email?.charAt(0) || 'U'}
+            </div>
+            <button className="btn-signout" onClick={signout}>
+              Sign out
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="dashboard-main">
+        {error && (
+          <div className="error-banner">
+            {error}
+            <button onClick={() => setError('')}>×</button>
+          </div>
+        )}
+
+        {/* Hero Section - shown when no notebooks or no search */}
+        {notebooks.length === 0 && !searchQuery && (
+          <section className="hero-section">
+            <div className="hero-content">
+              <h1>Welcome to NotebookLM</h1>
+              <p>
+                Upload your documents, ask questions, and take notes with AI-powered assistance.
+                Create your first notebook to get started.
+              </p>
+              <button
+                className="btn-create-hero"
+                onClick={() => setShowCreateModal(true)}
+              >
+                <span>+</span> Create your first notebook
+              </button>
+            </div>
+            <div className="hero-illustration">
+              <div className="illustration-card">📄</div>
+              <div className="illustration-card">💬</div>
+              <div className="illustration-card">📝</div>
+            </div>
+          </section>
+        )}
+
+        {/* Recent Notebooks */}
+        {notebooks.length > 0 && !searchQuery && (
+          <section className="notebooks-section">
+            <div className="section-header">
+              <h2>Recent notebooks</h2>
+            </div>
+            <div className="notebooks-grid">
+              {/* Create New Card */}
+              <div
+                className="notebook-card create-card"
+                onClick={() => setShowCreateModal(true)}
+              >
+                <div className="create-card-content">
+                  <div className="create-icon">+</div>
+                  <span>New notebook</span>
+                </div>
+              </div>
+
+              {recentNotebooks.map((notebook) => (
+                <NotebookCard
+                  key={notebook.id}
+                  id={notebook.id}
+                  title={notebook.title}
+                  content={notebook.content}
+                  updatedAt={notebook.updatedAt}
+                  onClick={() => handleOpenNotebook(notebook.id)}
+                  onDelete={(e) => handleDeleteNotebook(e, notebook.id, notebook.title)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* All Notebooks (shown when there are more than 4 or when searching) */}
+        {(notebooks.length > 4 || searchQuery) && (
+          <section className="notebooks-section">
+            <div className="section-header">
+              <h2>{searchQuery ? 'Search results' : 'All notebooks'}</h2>
+              <span className="notebook-count">
+                {filteredNotebooks.length} notebook{filteredNotebooks.length !== 1 ? 's' : ''}
+              </span>
+            </div>
+            {filteredNotebooks.length === 0 ? (
+              <div className="empty-search">
+                <div className="empty-icon">🔍</div>
+                <p>No notebooks found for "{searchQuery}"</p>
+              </div>
+            ) : (
+              <div className="notebooks-grid">
+                {!searchQuery && (
+                  <div
+                    className="notebook-card create-card"
+                    onClick={() => setShowCreateModal(true)}
+                  >
+                    <div className="create-card-content">
+                      <div className="create-icon">+</div>
+                      <span>New notebook</span>
+                    </div>
+                  </div>
+                )}
+                {filteredNotebooks.map((notebook) => (
+                  <NotebookCard
+                    key={notebook.id}
+                    id={notebook.id}
+                    title={notebook.title}
+                    content={notebook.content}
+                    updatedAt={notebook.updatedAt}
+                    onClick={() => handleOpenNotebook(notebook.id)}
+                    onDelete={(e) => handleDeleteNotebook(e, notebook.id, notebook.title)}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </main>
+
+      {/* Create Notebook Modal */}
+      {showCreateModal && (
+        <div className="modal-overlay" onClick={() => setShowCreateModal(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>Create new notebook</h2>
+              <button
+                className="modal-close"
+                onClick={() => setShowCreateModal(false)}
+              >
+                ×
+              </button>
+            </div>
+            <div className="modal-body">
+              <label htmlFor="notebook-title">Notebook name</label>
+              <input
+                id="notebook-title"
+                type="text"
+                placeholder="Enter notebook name..."
+                value={newNotebookTitle}
+                onChange={(e) => setNewNotebookTitle(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleCreateNotebook()}
+                autoFocus
+              />
+            </div>
+            <div className="modal-footer">
+              <button
+                className="btn-cancel"
+                onClick={() => setShowCreateModal(false)}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn-create"
+                onClick={handleCreateNotebook}
+                disabled={!newNotebookTitle.trim() || isCreating}
+              >
+                {isCreating ? 'Creating...' : 'Create'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Floating Action Button for quick create */}
+      {notebooks.length > 0 && (
+        <button
+          className="fab"
+          onClick={handleQuickCreate}
+          disabled={isCreating}
+          title="Create new notebook"
+        >
+          +
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default NotebookDashboard;

--- a/frontend/src/styles/NotebookDashboard.css
+++ b/frontend/src/styles/NotebookDashboard.css
@@ -1,0 +1,694 @@
+/* NotebookLM-inspired Dashboard Styles */
+
+.dashboard {
+  min-height: 100vh;
+  background: #f8f9fa;
+  font-family: 'Google Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Loading State */
+.dashboard-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1.5rem;
+}
+
+.dashboard-loading .loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid #e0e0e0;
+  border-top-color: #1a73e8;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.dashboard-loading p {
+  color: #5f6368;
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* Header */
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+}
+
+.app-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logo-icon {
+  font-size: 1.75rem;
+}
+
+.logo-text {
+  font-size: 1.375rem;
+  font-weight: 500;
+  color: #202124;
+}
+
+.header-center {
+  flex: 1;
+  max-width: 720px;
+  margin: 0 2rem;
+}
+
+.search-container {
+  display: flex;
+  align-items: center;
+  background: #f1f3f4;
+  border-radius: 24px;
+  padding: 0.5rem 1rem;
+  transition: all 0.2s;
+}
+
+.search-container:focus-within {
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.3), 0 4px 8px 3px rgba(60, 64, 67, 0.15);
+}
+
+.search-icon {
+  margin-right: 0.75rem;
+  opacity: 0.6;
+}
+
+.search-container .search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  padding: 0.25rem 0;
+  outline: none;
+}
+
+.search-clear {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  color: #5f6368;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+.search-clear:hover {
+  background: #e0e0e0;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.user-menu {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.user-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #1a73e8;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  font-size: 0.9375rem;
+  text-transform: uppercase;
+}
+
+.btn-signout {
+  padding: 0.5rem 1rem;
+  background: none;
+  border: 1px solid #dadce0;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  color: #5f6368;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-signout:hover {
+  background: #f1f3f4;
+  border-color: #1a73e8;
+  color: #1a73e8;
+}
+
+/* Main Content */
+.dashboard-main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.error-banner {
+  background: #fce8e6;
+  color: #c5221f;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.error-banner button {
+  background: none;
+  border: none;
+  color: #c5221f;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* Hero Section */
+.hero-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4rem 2rem;
+  background: linear-gradient(135deg, #e8f0fe 0%, #d2e3fc 100%);
+  border-radius: 24px;
+  margin-bottom: 3rem;
+}
+
+.hero-content {
+  max-width: 500px;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  font-weight: 400;
+  color: #202124;
+  margin: 0 0 1rem 0;
+}
+
+.hero-content p {
+  font-size: 1.125rem;
+  color: #5f6368;
+  line-height: 1.6;
+  margin: 0 0 2rem 0;
+}
+
+.btn-create-hero {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1.5rem;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 24px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
+}
+
+.btn-create-hero:hover {
+  background: #1557b0;
+  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.3), 0 4px 8px 3px rgba(60, 64, 67, 0.15);
+}
+
+.btn-create-hero span {
+  font-size: 1.25rem;
+  font-weight: 300;
+}
+
+.hero-illustration {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.illustration-card {
+  width: 100px;
+  height: 120px;
+  background: white;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  box-shadow: 0 2px 6px rgba(60, 64, 67, 0.15);
+  transform: rotate(-3deg);
+}
+
+.illustration-card:nth-child(2) {
+  transform: rotate(2deg);
+  margin-top: 1rem;
+}
+
+.illustration-card:nth-child(3) {
+  transform: rotate(-1deg);
+  margin-top: 0.5rem;
+}
+
+/* Notebooks Section */
+.notebooks-section {
+  margin-bottom: 3rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.section-header h2 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: #202124;
+  margin: 0;
+}
+
+.notebook-count {
+  font-size: 0.875rem;
+  color: #5f6368;
+}
+
+.notebooks-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+/* Notebook Card */
+.notebook-card {
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);
+}
+
+.notebook-card:hover {
+  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.3), 0 4px 8px 3px rgba(60, 64, 67, 0.15);
+  transform: translateY(-2px);
+}
+
+.notebook-card-header {
+  height: 100px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1rem;
+  background: #4285f4;
+}
+
+.notebook-card-icon {
+  font-size: 2rem;
+  background: rgba(255, 255, 255, 0.2);
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.notebook-card-menu {
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  color: white;
+  font-size: 1.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.notebook-card:hover .notebook-card-menu {
+  opacity: 1;
+}
+
+.notebook-card-menu:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.notebook-card-body {
+  padding: 1rem 1.25rem;
+}
+
+.notebook-card-title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #202124;
+  margin: 0 0 0.5rem 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notebook-card-preview {
+  font-size: 0.875rem;
+  color: #5f6368;
+  line-height: 1.5;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.625rem;
+}
+
+.notebook-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid #f1f3f4;
+}
+
+.notebook-card-date {
+  font-size: 0.75rem;
+  color: #5f6368;
+}
+
+.notebook-card-sources {
+  font-size: 0.75rem;
+  color: #1a73e8;
+  font-weight: 500;
+}
+
+/* Create Card */
+.notebook-card.create-card {
+  border: 2px dashed #dadce0;
+  box-shadow: none;
+  background: transparent;
+}
+
+.notebook-card.create-card:hover {
+  border-color: #1a73e8;
+  background: #e8f0fe;
+  transform: none;
+  box-shadow: none;
+}
+
+.create-card-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  gap: 1rem;
+  color: #5f6368;
+}
+
+.notebook-card.create-card:hover .create-card-content {
+  color: #1a73e8;
+}
+
+.create-icon {
+  width: 56px;
+  height: 56px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 300;
+}
+
+.create-card-content span {
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+/* Empty Search */
+.empty-search {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #5f6368;
+}
+
+.empty-search .empty-icon {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  opacity: 0.5;
+}
+
+.empty-search p {
+  font-size: 1.125rem;
+  margin: 0;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal {
+  background: white;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 8px 28px rgba(60, 64, 67, 0.3);
+  animation: slideUp 0.3s;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.modal-header h2 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: #202124;
+  margin: 0;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: #5f6368;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-close:hover {
+  background: #f1f3f4;
+}
+
+.modal-body {
+  padding: 1.5rem;
+}
+
+.modal-body label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #5f6368;
+  margin-bottom: 0.5rem;
+}
+
+.modal-body input {
+  width: 100%;
+  padding: 0.875rem 1rem;
+  border: 1px solid #dadce0;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s;
+}
+
+.modal-body input:focus {
+  outline: none;
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.2);
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.btn-cancel {
+  padding: 0.625rem 1.25rem;
+  background: none;
+  border: 1px solid #dadce0;
+  border-radius: 20px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: #5f6368;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-cancel:hover {
+  background: #f1f3f4;
+}
+
+.btn-create {
+  padding: 0.625rem 1.5rem;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 20px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-create:hover:not(:disabled) {
+  background: #1557b0;
+}
+
+.btn-create:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* FAB */
+.fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  font-size: 2rem;
+  font-weight: 300;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(60, 64, 67, 0.3), 0 6px 16px 3px rgba(60, 64, 67, 0.15);
+  transition: all 0.2s;
+  z-index: 50;
+}
+
+.fab:hover:not(:disabled) {
+  background: #1557b0;
+  box-shadow: 0 4px 8px rgba(60, 64, 67, 0.3), 0 8px 20px 3px rgba(60, 64, 67, 0.15);
+  transform: scale(1.05);
+}
+
+.fab:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .dashboard-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding: 1rem;
+  }
+
+  .header-center {
+    order: 3;
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+  }
+
+  .hero-section {
+    flex-direction: column;
+    text-align: center;
+    padding: 2rem;
+  }
+
+  .hero-illustration {
+    display: none;
+  }
+
+  .hero-content h1 {
+    font-size: 1.75rem;
+  }
+
+  .dashboard-main {
+    padding: 1rem;
+  }
+
+  .notebooks-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fab {
+    bottom: 1.5rem;
+    right: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Added `NotebookCard` component with hash-based colored headers and content preview
- Created `NotebookDashboard` page with responsive grid layout, hero section for empty state, create notebook modal, and floating action button
- Updated routing to separate dashboard view (`/notebooks`) from editor view (`/notebooks/:notebookId`)
- Refactored `Notebooks.tsx` to work with URL params for single notebook viewing

## Test plan
- [ ] Verify login redirects to /notebooks dashboard
- [ ] Test creating a new notebook from modal and FAB
- [ ] Test opening a notebook navigates to three-pane editor
- [ ] Test search filtering on the dashboard
- [ ] Test deleting a notebook from the card
- [ ] Verify responsive layout on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)